### PR TITLE
fix: ensure enemy phase announcement displays correctly during AI turns

### DIFF
--- a/src/lab/experiments/gamev1_3/components/TurnAnnouncement.tsx
+++ b/src/lab/experiments/gamev1_3/components/TurnAnnouncement.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from 'react';
+import type { TurnState } from '../types/TurnState';
+
+interface Props {
+  message: string;
+}
+
+export const TurnAnnouncement: React.FC<Props> = ({ message }) => {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setVisible(false), 1000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div style={{
+      position: 'fixed',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: 'rgba(0, 0, 0, 0.7)',
+      color: 'white',
+      fontSize: '32px',
+      fontWeight: 'bold',
+      zIndex: 1000,
+      animation: 'fadeInOut 1s ease-in-out',
+    }}>
+      {message}
+      <style>
+        {`
+          @keyframes fadeInOut {
+            0% { opacity: 0; }
+            20% { opacity: 1; }
+            80% { opacity: 1; }
+            100% { opacity: 0; }
+          }
+        `}
+      </style>
+    </div>
+  );
+};
+
+export function getAnnouncementMessage(turnState: TurnState): string {
+    console.log('turnState', turnState);
+  if (turnState.phase === 'ally') return '盟军行动';
+  if (turnState.phase === 'enemy') return '敌军行动';
+  if (turnState.phase === 'player') {
+    return `第${turnState.number}回合 - ${turnState.cycle === 'day' ? '白天' : '夜晚'}`;
+  }
+  return '';
+} 

--- a/src/lab/experiments/gamev1_3/systems/TurnSystem.ts
+++ b/src/lab/experiments/gamev1_3/systems/TurnSystem.ts
@@ -14,11 +14,6 @@ export interface TurnState {
 function handleCharacteristicEffects(unit: UnitData, event: PhaseEvent): UnitData {
   let updatedUnit = { ...unit };
   
-  // Debug logging
-  console.log('Processing unit:', unit.id, 'for event:', event);
-  console.log('Current characteristics:', unit.characteristics);
-  console.log('Current buffs:', unit.buffs);
-  
   switch(event) {
     case 'onDayStart':
       if (hasCharacteristic(unit.characteristics, [], 'dayWalker') && 
@@ -63,7 +58,6 @@ function handleCharacteristicEffects(unit: UnitData, event: PhaseEvent): UnitDat
       break;
   }
 
-  console.log('Updated unit:', updatedUnit);
   return updatedUnit;
 }
 
@@ -110,12 +104,15 @@ export function handleFactionTurn(units: UnitData[], faction: UnitFaction): Unit
 
 // TODO: Implement AI movement for ally and enemy units
 export function handleAITurn(units: UnitData[], faction: UnitFaction): UnitData[] {
+  // First, reset movement for units of the current faction
+  const resetUnits = handleFactionTurn(units, faction);
+  
   // TODO: Add AI logic for unit movement
-  // TODO: Consider:
   // - Path finding
   // - Target selection
   // - Combat decisions
   // - Formation maintenance
   // - Strategic objectives
-  return units;
+  
+  return resetUnits; // Return units with reset movement, even if AI hasn't moved yet
 } 


### PR DESCRIPTION
- Add phase announcement display.
- Blocks player actions during AI thinking/turn